### PR TITLE
Cleaned up the ringbuf library

### DIFF
--- a/lib/ringbuf/ringbuf.c
+++ b/lib/ringbuf/ringbuf.c
@@ -4,14 +4,13 @@
 #include <stdint.h>
 
 #include "ringbuf.h"
-// allocate and init
-Ringbuf *ringbuf_init(Ringbuf **rb, int num_keys){
+
+// Allocate and initialize a ringbuffer
+Ringbuf *ringbuf_init(Ringbuf **rb, uint64_t num_keys){
 	*rb = malloc(sizeof(Ringbuf));
 	(*rb)->keys = malloc(num_keys*sizeof(void *));
-	int m_alloced = sizeof(Ringbuf)+num_keys*sizeof(void *);
 	int i;
 	if (*rb){
-		//printf("Initializing ring buffer: keys[%d] (%d KB allocated)\n", num_keys, m_alloced/1024);
 		memset(*rb, 0, sizeof(*rb));
 		(*rb)->num_keys = num_keys;
 		for(i = 0; i < num_keys; i++){
@@ -24,38 +23,33 @@ Ringbuf *ringbuf_init(Ringbuf **rb, int num_keys){
 	return (*rb);
 }
 
-// clear
+// Free all data in the buffer, as well as the keys structure
 void ringbuf_clear(Ringbuf *rb){
 	int i;
 	for(i=0; i< rb->num_keys; i++){
 		if(rb->keys[i] != NULL){
 			free(rb->keys[i]);
+			rb->keys[i] = NULL;
 		}
-		rb->keys[i] = NULL;
 	}
 	free(rb->keys);
 	rb->write = 0;
 	rb->read = 0;
 	rb->fill = 0;
 }
+
+// Allocate a new buffer and give it control of all of the argument buffer's keys.
+// Only allocates enough space to hold all of the unread keys in the argument buffer,
+//   and only actually copies the keys, not the memory they point to.
 Ringbuf *ringbuf_copy(Ringbuf *rb){
 	Ringbuf *out;
 	out = ringbuf_init(&out, rb->fill+1);
 	int i;
-	/*
+	uint64_t offset = rb->read;
 	for(i = rb->read; i != rb->write; i=(i+1)%(rb->num_keys)){
-		out->keys[i] = rb->keys[i]; // now out is in charge of the memory
-		rb->keys[i] = NULL;
-	}
-	*/
-	int offset = rb->read;
-	for(i = rb->read; i != rb->write; i=(i+1)%(rb->num_keys)){
-		//printf("%d %d %lu\n", i-offset, i, rb->write);
 		out->keys[i-offset] = rb->keys[i];
 		rb->keys[i] = NULL;
 	}
-	//out->write = rb->write;
-	//out->read = rb->read;
 	out->read = 0;
 	out->write = rb->fill;
 	out->fill = rb->fill;
@@ -65,67 +59,110 @@ Ringbuf *ringbuf_copy(Ringbuf *rb){
 	return out;
 }
 
-// debugging
+// Create an exact duplicate of the current ringbuffer,
+//   including making a copy of every memory object pointed to
+//   by any of the keys.
+Ringbuf *ringbuf_dup(Ringbuf *rb){
+	Ringbuf *out;
+	out = ringbuf_init(&out, rb->num_keys);
+	int i;
+	for(i = 0; i < rb->num_keys; i++){
+		if(rb->keys[i] != NULL){
+			size_t memsize = sizeof(*(rb->keys[i]));
+			out->keys[i] = calloc(1, memsize);
+			memcpy(out->keys[i], rb->keys[i], memsize);
+		}
+		else {
+			out->keys[i] = NULL;
+		}
+	}
+	out->write = rb->write;
+	out->read = rb->read;
+	out->fill = rb->fill;
+	return out;
+}
+
+// Print out values of the ringbuf (for debugging).
 void ringbuf_status(Ringbuf *rb, char *pref){
-	printf("%sRingbuf at %p:\n", pref, rb);
-	printf("%s  write: %lu\n", pref, rb->write);
-	printf("%s   read: %lu\n", pref, rb->read);
-	printf("%s   fill: %lu\n", pref, rb->fill);
+	printf("%sRingbuf  %p:\n", pref, rb);
+	printf("%s  write: %llu\n", pref, rb->write);
+	printf("%s   read: %llu\n", pref, rb->read);
+	printf("%s   fill: %llu\n", pref, rb->fill);
 	printf("%s   full: %d\n", pref, ringbuf_isfull(rb));
 	printf("%s  empty: %d\n", pref, ringbuf_isempty(rb));
 }
 	
-// state
+// Check the state of a ringbuf
 int ringbuf_isfull(Ringbuf *rb){
 	return ( ((rb->write) == (rb->read)) && (rb->fill != 0) );
 }
 int ringbuf_isempty(Ringbuf *rb){
 	return ( ((rb->write) == (rb->read)) && (rb->fill == 0) );
 }
-// add / remove
-int ringbuf_push(Ringbuf *rb, void *key, size_t size){
+
+// Have the ringbuf keep track of some amount of data by storing
+//   the address to it.
+int ringbuf_push(Ringbuf *rb, void *memaddr){
 	int full = ringbuf_isfull(rb);
 	if (!full){
-		rb->keys[rb->write] = key;
-		//rb->keys[rb->write] = malloc(sizeof(key)); // allocate some space
-		//memcpy(rb->keys[rb->write], key, sizeof(key));
-		//rb->keys[rb->write] = malloc(size);
-		//memcpy(rb->keys[rb->write], key, size);
+		rb->keys[rb->write] = memaddr;
 		rb->write++;
 		rb->write %= rb->num_keys;
 		rb->fill++;
 	}
 	return !full;
 }
+// Copy some data and have the ringbuf keep track of the new copy.
+int ringbuf_pushcp(Ringbuf *rb, void *memaddr, size_t size){
+	int full = ringbuf_isfull(rb);
+	if (!full){
+		rb->keys[rb->write] = calloc(1, size);
+		memcpy(rb->keys[rb->write], memaddr, size);
+		rb->write++;
+		rb->write %= rb->num_keys;
+		rb->fill++;
+	}
+	return !full;
+}
+		
+// Read some data from the ringbuf by copying the key into the given destination,
+//   removing the key from the ringbuf in the process.
 int ringbuf_pop(Ringbuf *rb, void **dest){
 	int empty = ringbuf_isempty(rb);
 	if (!empty){
 		(*dest) = rb->keys[rb->read];
 		rb->keys[rb->read] = NULL;
-		//memcpy((*dest), rb->keys[rb->read], sizeof(rb->keys[rb->read]));
-		//if(rb->keys[rb->read] != NULL){
-			//free(rb->keys[rb->read]);
-		//}
 		rb->read++; // note: you can pop a NULL pointer off the end
 		rb->read %= rb->num_keys;
 		rb->fill--;
 	}
 	return !empty;
 }
+
+// Insert a pointer into an arbitrary location of the ringbuf, using
+//   a modulus so that the location is always valid. If that key
+//   already exists and the overwrite argument != 0, the memory it
+//   points to is freed and the key overwritten.
 int ringbuf_insert(Ringbuf *rb, int elem, void *key, int overwrite){
 	int loc = elem % rb->num_keys;
 	int full = ringbuf_isfull(rb);
-	if (!full || overwrite) {
-		if(rb->keys[loc] != NULL){
+	if(rb->keys[loc] != NULL){
+		if(overwrite){
 			rb->fill--;
 			free(rb->keys[loc]);
 		}
-		rb->keys[loc] = key;
-		rb->fill++;
-		return 0;
+		else{
+			return -1;
+		}
 	}
-	return 1;
+	rb->keys[loc] = key;
+	rb->fill++;
+	return 0;
 }
+
+// Grab the key at a specific location, using a modulus
+//   to ensure always-valid locations, and store it in
+//   dest.
 int ringbuf_get(Ringbuf *rb, int elem, void **dest){
 	int loc = elem % rb->num_keys;
 	*dest = rb->keys[loc];

--- a/lib/ringbuf/ringbuf.h
+++ b/lib/ringbuf/ringbuf.h
@@ -13,20 +13,22 @@ typedef struct {
 	uint64_t fill;		// fillcount (+writemoves -readmoves);
 } Ringbuf;
 
-// allocate and init
-Ringbuf *ringbuf_init(Ringbuf **rb, int num_keys);
-// clear
+Ringbuf *ringbuf_init(Ringbuf **rb, uint64_t num_keys);
 void ringbuf_clear(Ringbuf *rb);
-// "copy" (move)
+
 Ringbuf *ringbuf_copy(Ringbuf *rb);
-// debugging
+Ringbuf *ringbuf_dup(Ringbuf *rb);
+
 void ringbuf_status(Ringbuf *rb, char *pref);
-// state
+
 int ringbuf_isfull(Ringbuf *rb);
 int ringbuf_isempty(Ringbuf *rb);
-// add / remove
-int ringbuf_push(Ringbuf *rb, void *key, size_t size);
+
+int ringbuf_push(Ringbuf *rb, void *memaddr);
+int ringbuf_pushcp(Ringbuf *rb, void *memaddr, size_t size);
+
 int ringbuf_pop(Ringbuf *rb, void **dest);
-int ringbuf_insert(Ringbuf *rb, int elem, void *key, int overwrite);
 int ringbuf_get(Ringbuf *rb, int elem, void **dest);
+
+int ringbuf_insert(Ringbuf *rb, int elem, void *key, int overwrite);
 #endif

--- a/snotstream.c
+++ b/snotstream.c
@@ -284,7 +284,7 @@ void parse_xl3(void *data_pkt){
 		data->chan = (uint32_t) UNPK_CHANNEL_ID((uint32_t *)&bndl_array[i]);
 		data->pmt = 512*(data->crate)+32*(data->board)+(data->chan);
 		if(!ringbuf_isfull(xl3_buf)){
-			ringbuf_push(xl3_buf, data, 0); // TODO: fix push size
+			ringbuf_push(xl3_buf, data);
 		}
 		else { // If the buffer is full, we've fallen behind.
 			fprintf(stderr, "parse_xl3: ran out of room!\


### PR DESCRIPTION
Created ringbuf_pushcp for pushing copies of data,
ringbuf_push just pushes a pointer. ringbuf_pushcp takes size
argument but ringbuf_push doesn't. Updated the documentation
(the comments on ringbuf.h).

Because ringbuf_push used to take a size argument, I had to
change the one call to it in snotstream.c
